### PR TITLE
Trouble shooting: dep_path not relative to repo head in annotated tactics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,13 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Helping files 
+scripts/helper.py
+test3.py
+test4.py
+
+# Products & demos
+leandojo_benchmark_4/
+traced_lean-example/
+traced_lean4-example/

--- a/scripts/generate-benchmark-lean4.ipynb
+++ b/scripts/generate-benchmark-lean4.ipynb
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 29,
    "id": "5710e141",
    "metadata": {},
    "outputs": [],
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 30,
    "id": "a34ccdfb",
    "metadata": {},
    "outputs": [],
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 31,
    "id": "f1beb027",
    "metadata": {},
    "outputs": [],
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 32,
    "id": "e150f547",
    "metadata": {},
    "outputs": [],
@@ -181,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 33,
    "id": "03882cc5",
    "metadata": {},
    "outputs": [],
@@ -207,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 34,
    "id": "06e6fe8d",
    "metadata": {},
    "outputs": [],
@@ -314,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 35,
    "id": "bc50220e",
    "metadata": {
     "scrolled": true
@@ -324,19 +324,30 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2023-08-04 07:56:28.155\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mlean_dojo.data_extraction.trace\u001b[0m:\u001b[36mtrace\u001b[0m:\u001b[36m163\u001b[0m - \u001b[1mLoading the traced repo from /home/kaiyu/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4\u001b[0m\n",
-      "2023-08-04 07:56:30,131\tINFO worker.py:1627 -- Started a local Ray instance. View the dashboard at \u001b[1m\u001b[32m127.0.0.1:8265 \u001b[39m\u001b[22m\n",
-      "100%|██████████████████████████████████████| 4249/4249 [07:47<00:00,  9.08it/s]\n",
-      "\u001b[32m2023-08-04 08:05:16.273\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36msplit_data\u001b[0m:\u001b[36m3\u001b[0m - \u001b[1m101315 theorems in total\u001b[0m\n",
-      "\u001b[32m2023-08-04 08:05:16.275\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36msplit_randomly\u001b[0m:\u001b[36m18\u001b[0m - \u001b[1mSplitting the theorems randomly\u001b[0m\n",
-      "\u001b[32m2023-08-04 08:05:16.316\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36msplit_by_premise\u001b[0m:\u001b[36m8\u001b[0m - \u001b[1mSpliting the theorems by premises\u001b[0m\n",
-      "\u001b[32m2023-08-04 08:05:46.512\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m97315 theorems and 200607 tactics saved to ../leandojo_benchmark_4/random/train.json\u001b[0m\n",
-      "\u001b[32m2023-08-04 08:05:47.229\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 4247 tactics saved to ../leandojo_benchmark_4/random/val.json\u001b[0m\n",
-      "\u001b[32m2023-08-04 08:05:47.680\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 3942 tactics saved to ../leandojo_benchmark_4/random/test.json\u001b[0m\n",
-      "\u001b[32m2023-08-04 08:06:06.995\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m97315 theorems and 186267 tactics saved to ../leandojo_benchmark_4/novel_premises/train.json\u001b[0m\n",
-      "\u001b[32m2023-08-04 08:06:08.325\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 11216 tactics saved to ../leandojo_benchmark_4/novel_premises/val.json\u001b[0m\n",
-      "\u001b[32m2023-08-04 08:06:09.462\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 11313 tactics saved to ../leandojo_benchmark_4/novel_premises/test.json\u001b[0m\n",
-      "\u001b[32m2023-08-04 08:06:29.463\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m71\u001b[0m - \u001b[1m101315 theorems/definitions from 4249 files saved to ../leandojo_benchmark_4/corpus.jsonl\u001b[0m\n"
+      "\u001b[32m2023-08-07 02:18:29.446\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.trace\u001b[0m:\u001b[36mget_traced_repo_path\u001b[0m:\u001b[36m139\u001b[0m - \u001b[34m\u001b[1mThe traced repo is available in the cache.\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:18:29.446\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mlean_dojo.data_extraction.trace\u001b[0m:\u001b[36mtrace\u001b[0m:\u001b[36m163\u001b[0m - \u001b[1mLoading the traced repo from /home/peiyang/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:18:29.540\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.traced_data\u001b[0m:\u001b[36mload_from_disk\u001b[0m:\u001b[36m1456\u001b[0m - \u001b[34m\u001b[1mLoading 4249 traced XML files from /home/peiyang/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4 with 39 workers\u001b[0m\n",
+      "2023-08-07 02:18:34,132\tINFO worker.py:1627 -- Started a local Ray instance. View the dashboard at \u001b[1m\u001b[32m127.0.0.1:8265 \u001b[39m\u001b[22m\n",
+      "100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4249/4249 [09:58<00:00,  7.10it/s]\n",
+      "\u001b[32m2023-08-07 02:31:23.139\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/leanprover/doc-gen4 \"main\"\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:31:23.721\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/leanprover/std4 \"main\"\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:31:24.407\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/gebner/quote4 \"master\"\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:31:24.884\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/JLimperg/aesop \"master\"\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:31:25.476\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/mhuisi/lean4-cli \"nightly\"\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:31:25.921\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/EdAyers/ProofWidgets4 \"v0.0.13\"\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:31:51.644\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.traced_data\u001b[0m:\u001b[36mcheck_sanity\u001b[0m:\u001b[36m1320\u001b[0m - \u001b[34m\u001b[1mChecking the sanity of TracedRepo(repo=LeanGitRepo(url='https://github.com/leanprover-community/mathlib4', commit='067bc406f149a6664640db1f1a6b1e285785deff'), dependencies={'lean4': LeanGitRepo(url='https://github.com/leanprover/lean4', commit='125a0ba798e75fe8eb79b7ae09b25e7c760eadd5'), '«doc-gen4»': LeanGitRepo(url='https://github.com/leanprover/doc-gen4', commit='596782c1fee6e6b4a77e278f3b4f78643d1a7752'), 'std': LeanGitRepo(url='https://github.com/leanprover/std4', commit='7601c54efadd70b688a163f5dcc11ae0ccdf7621'), 'Qq': LeanGitRepo(url='https://github.com/gebner/quote4', commit='81cc13c524a68d0072561dbac276cd61b65872a6'), 'aesop': LeanGitRepo(url='https://github.com/JLimperg/aesop', commit='354432d437fb37738ed93ac6988669d78a870ed0'), 'Cli': LeanGitRepo(url='https://github.com/mhuisi/lean4-cli', commit='5a858c32963b6b19be0d477a30a1f4b6c120be7e'), 'proofwidgets': LeanGitRepo(url='https://github.com/EdAyers/ProofWidgets4', commit='a0c2cd0ac3245a0dade4f925bcfa97e06dd84229')}, root_dir=PosixPath('/home/peiyang/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4'))\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:32:08.468\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36msplit_data\u001b[0m:\u001b[36m3\u001b[0m - \u001b[1m101315 theorems in total\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:32:08.470\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36msplit_randomly\u001b[0m:\u001b[36m18\u001b[0m - \u001b[1mSplitting the theorems randomly\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:32:08.511\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36msplit_by_premise\u001b[0m:\u001b[36m8\u001b[0m - \u001b[1mSpliting the theorems by premises\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:32:17.213\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m11\u001b[0m - \u001b[33m\u001b[1m../leandojo_benchmark_4 already exists. Removing it now.\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:33:50.137\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m97315 theorems and 200240 tactics saved to ../leandojo_benchmark_4/random/train.json\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:33:52.325\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 4311 tactics saved to ../leandojo_benchmark_4/random/val.json\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:33:54.384\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 4245 tactics saved to ../leandojo_benchmark_4/random/test.json\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:35:16.459\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m97315 theorems and 185045 tactics saved to ../leandojo_benchmark_4/novel_premises/train.json\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:35:23.243\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 11519 tactics saved to ../leandojo_benchmark_4/novel_premises/val.json\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:35:29.550\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 12232 tactics saved to ../leandojo_benchmark_4/novel_premises/test.json\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:35:48.816\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m71\u001b[0m - \u001b[1m101315 theorems/definitions from 4249 files saved to ../leandojo_benchmark_4/corpus.jsonl\u001b[0m\n",
+      "\u001b[32m2023-08-07 02:35:50.512\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.utils\u001b[0m:\u001b[36mread_url\u001b[0m:\u001b[36m238\u001b[0m - \u001b[34m\u001b[1mRequset to https://raw.githubusercontent.com/gebner/quote4/81cc13c524a68d0072561dbac276cd61b65872a6/LICENSE failed. Retrying...\u001b[0m\n"
      ]
     }
    ],
@@ -386,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 36,
    "id": "7427982d",
    "metadata": {},
    "outputs": [
@@ -412,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 37,
    "id": "cbca21c9",
    "metadata": {},
    "outputs": [
@@ -422,7 +433,7 @@
        "dict_keys(['path', 'imports', 'premises'])"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -444,18 +455,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 38,
    "id": "f5c1920a",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "('Mathlib/Data/List/Duplicate.lean',\n",
-       " ['Mathlib/Data/List/Nodup.lean', 'lake-packages/lean4/src/lean/Init.lean'])"
+       "('Mathlib/Data/Finset/Prod.lean',\n",
+       " ['Mathlib/Data/Finset/Card.lean', 'lake-packages/lean4/src/lean/Init.lean'])"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -466,17 +477,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 39,
    "id": "d801a0ae",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "20"
+       "61"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -495,21 +506,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 40,
    "id": "b533d342",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'full_name': 'List.Mem.duplicate_cons_self',\n",
-       " 'code': 'theorem Mem.duplicate_cons_self (h : x ∈ l) : x ∈+ x :: l',\n",
-       " 'start': [39, 1],\n",
-       " 'end': [40, 23],\n",
+       "{'full_name': 'Finset.product_val',\n",
+       " 'code': 'theorem product_val : (s ×ˢ t).1 = s.1 ×ˢ t.1',\n",
+       " 'start': [48, 1],\n",
+       " 'end': [49, 6],\n",
        " 'kind': 'commandtheoremn'}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -533,17 +544,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 41,
    "id": "4fb19aa3",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "96631"
+       "96637"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -564,7 +575,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 42,
    "id": "3cc47f7e",
    "metadata": {},
    "outputs": [
@@ -574,7 +585,7 @@
        "dict_keys(['url', 'commit', 'file_path', 'full_name', 'start', 'end', 'traced_tactics'])"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -588,7 +599,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 43,
    "id": "3c2c36a7",
    "metadata": {},
    "outputs": [
@@ -597,11 +608,11 @@
       "text/plain": [
        "('https://github.com/leanprover-community/mathlib4',\n",
        " '067bc406f149a6664640db1f1a6b1e285785deff',\n",
-       " 'Mathlib/RingTheory/Polynomial/Dickson.lean',\n",
-       " 'Polynomial.dickson_two')"
+       " 'Mathlib/FieldTheory/Minpoly/Basic.lean',\n",
+       " 'minpoly.subsingleton')"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -620,17 +631,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 44,
    "id": "c29987ff",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1"
+       "7"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -649,30 +660,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 47,
    "id": "a734d788",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'tactic': 'simp only [dickson, sq]',\n",
-       " 'annotated_tactic': ['simp only [dickson, <a>sq</a>]',\n",
-       "  [{'full_name': 'sq',\n",
-       "    'def_path': 'Mathlib/Algebra/GroupPower/Basic.lean',\n",
-       "    'def_pos': [106, 17],\n",
-       "    'def_end_pos': [106, 19]}]],\n",
-       " 'state_before': 'R : Type u_1\\nS : Type ?u.24280\\ninst✝¹ : CommRing R\\ninst✝ : CommRing S\\nk : ℕ\\na : R\\n⊢ dickson k a 2 = X ^ 2 - ↑C a * (3 - ↑k)',\n",
-       " 'state_after': 'no goals'}"
+       "{'tactic': 'have := minpoly.min A x monic_one (Subsingleton.elim _ _)',\n",
+       " 'annotated_tactic': ['have := minpoly.min A x <a>monic_one</a> (<a>Subsingleton.elim</a> _ _)',\n",
+       "  [{'full_name': 'Polynomial.monic_one',\n",
+       "    'def_path': 'Mathlib/Data/Polynomial/Degree/Definitions.lean',\n",
+       "    'def_pos': [851, 9],\n",
+       "    'def_end_pos': [851, 18]},\n",
+       "   {'full_name': 'Subsingleton.elim',\n",
+       "    'def_path': 'lake-packages/lean4/src/lean/Init/Core.lean',\n",
+       "    'def_pos': [873, 19],\n",
+       "    'def_end_pos': [873, 36]}]],\n",
+       " 'state_before': \"A : Type u_2\\nB : Type u_1\\nB' : Type ?u.54219\\ninst✝⁵ : CommRing A\\ninst✝⁴ : Ring B\\ninst✝³ : Ring B'\\ninst✝² : Algebra A B\\ninst✝¹ : Algebra A B'\\nx : B\\ninst✝ : Subsingleton B\\n✝ : Nontrivial A\\n⊢ minpoly A x = 1\",\n",
+       " 'state_after': \"A : Type u_2\\nB : Type u_1\\nB' : Type ?u.54219\\ninst✝⁵ : CommRing A\\ninst✝⁴ : Ring B\\ninst✝³ : Ring B'\\ninst✝² : Algebra A B\\ninst✝¹ : Algebra A B'\\nx : B\\ninst✝ : Subsingleton B\\n✝ : Nontrivial A\\nthis : degree (minpoly A x) ≤ degree 1\\n⊢ minpoly A x = 1\"}"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "proof[\"traced_tactics\"][0]"
+    "proof[\"traced_tactics\"][1]"
    ]
   },
   {
@@ -708,7 +723,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/src/lean_dojo/data_extraction/traced_data.py
+++ b/src/lean_dojo/data_extraction/traced_data.py
@@ -258,7 +258,7 @@ class TracedTactic:
                         )
                         prov = {"full_name": node.full_name}
                         def_path = (node.mod_name).replace(".", "/") + ".lean"
-                        prov["def_path"] = def_path
+                        prov["def_path"] = find_relative_path(str(lean_file.root_dir), def_path)
                         prov["def_pos"] = list(node.def_start)
                         prov["def_end_pos"] = list(node.def_end)
                         provenances.append(prov)
@@ -268,6 +268,36 @@ class TracedTactic:
             annot_tac.append(lean_file[cur : self.end])
 
             return "".join(annot_tac), provenances
+        
+
+
+def find_absolute_path(repo_path: str, file_path: str) -> str:
+    '''Find the absolute path of a file in a given repo folder.
+    Inputs: absolute path to the repo folder, partial path to the file.
+    Output: absolute path to the file.
+    Assumptions: the file is somewhere in the repo folder, though its exact location is unknown.
+    '''
+    for dirpath, _, filenames in os.walk(repo_path):
+        if os.path.basename(file_path) in filenames and dirpath.endswith(os.path.dirname(file_path)):
+            return dirpath + "/" + os.path.basename(file_path)
+    
+    return "Bad path"
+
+
+def find_relative_path(repo_path: str, file_path: str) -> str:
+    '''Find the relative path of a file in a given repo folder.
+    Inputs: absolute path to the repo folder, partial path to the file.
+    Output: relative path to the file from the repo folder.
+    Assumptions: the file is somewhere in the repo folder, though its exact location is unknown.
+    '''
+    if file_path.split(os.path.sep)[0] in os.listdir(repo_path):
+        return file_path
+    else:
+        abs_path = find_absolute_path(repo_path, file_path)
+        if abs_path == "Bad path":
+            return "Bad path"
+        else:
+            return os.path.relpath(abs_path, repo_path)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This pull request fixes the bug that some `dep_path` outputs from annotated tactics were not relative to the repo folder.

- This PR mainly modifies traced_data.py to post-process dep_path information. This was done by two main functions, `find_absolute_path` and `find_relative_path`, functionalities described in corresponding docstrings. A slight optimization is added to this part as well, shortcutting for the special case that the partial path head is itself a direct child of the repo folder.

- This PR has been tested with `generate-benchmark-lean4.ipynb`. Please refer to the last line of code which prints out annotated tactic outputs.