### PR TITLE
Fix known bugs related to dependency graph building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,8 +135,11 @@ dmypy.json
 scripts/helper.py
 test3.py
 test4.py
+testmathlib4.py
 
 # Products & demos
 leandojo_benchmark_4/
 traced_lean-example/
 traced_lean4-example/
+traced_mathlib4/
+archived/

--- a/scripts/demo-lean4.ipynb
+++ b/scripts/demo-lean4.ipynb
@@ -97,9 +97,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2023-08-04 07:59:07.771\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mlean_dojo.data_extraction.trace\u001b[0m:\u001b[36mtrace\u001b[0m:\u001b[36m163\u001b[0m - \u001b[1mLoading the traced repo from /home/kaiyu/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4\u001b[0m\n",
-      "2023-08-04 07:59:09,778\tINFO worker.py:1627 -- Started a local Ray instance. View the dashboard at \u001b[1m\u001b[32m127.0.0.1:8266 \u001b[39m\u001b[22m\n",
-      "100%|██████████████████████████████████████| 4249/4249 [08:08<00:00,  8.70it/s]\n"
+      "\u001b[32m2023-08-09 00:32:11.507\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.trace\u001b[0m:\u001b[36mget_traced_repo_path\u001b[0m:\u001b[36m139\u001b[0m - \u001b[34m\u001b[1mThe traced repo is available in the cache.\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:32:11.508\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mlean_dojo.data_extraction.trace\u001b[0m:\u001b[36mtrace\u001b[0m:\u001b[36m163\u001b[0m - \u001b[1mLoading the traced repo from /home/peiyang/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:32:11.600\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.traced_data\u001b[0m:\u001b[36mload_from_disk\u001b[0m:\u001b[36m1456\u001b[0m - \u001b[34m\u001b[1mLoading 4249 traced XML files from /home/peiyang/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4 with 39 workers\u001b[0m\n",
+      "2023-08-09 00:32:13,648\tINFO worker.py:1627 -- Started a local Ray instance. View the dashboard at \u001b[1m\u001b[32m127.0.0.1:8265 \u001b[39m\u001b[22m\n",
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4249/4249 [07:45<00:00,  9.12it/s]\n",
+      "\u001b[32m2023-08-09 00:40:04.463\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/leanprover/doc-gen4 \"main\"\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:40:06.050\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/leanprover/std4 \"main\"\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:40:07.899\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/gebner/quote4 \"master\"\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:40:09.385\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/JLimperg/aesop \"master\"\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:40:10.882\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/mhuisi/lean4-cli \"nightly\"\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:40:12.496\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/EdAyers/ProofWidgets4 \"v0.0.13\"\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:40:38.098\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.traced_data\u001b[0m:\u001b[36mcheck_sanity\u001b[0m:\u001b[36m1320\u001b[0m - \u001b[34m\u001b[1mChecking the sanity of TracedRepo(repo=LeanGitRepo(url='https://github.com/leanprover-community/mathlib4', commit='067bc406f149a6664640db1f1a6b1e285785deff'), dependencies={'lean4': LeanGitRepo(url='https://github.com/leanprover/lean4', commit='125a0ba798e75fe8eb79b7ae09b25e7c760eadd5'), '«doc-gen4»': LeanGitRepo(url='https://github.com/leanprover/doc-gen4', commit='596782c1fee6e6b4a77e278f3b4f78643d1a7752'), 'std': LeanGitRepo(url='https://github.com/leanprover/std4', commit='17c3833ab170ce20fd065ae3fb550300b3d85f23'), 'Qq': LeanGitRepo(url='https://github.com/gebner/quote4', commit='81cc13c524a68d0072561dbac276cd61b65872a6'), 'aesop': LeanGitRepo(url='https://github.com/JLimperg/aesop', commit='354432d437fb37738ed93ac6988669d78a870ed0'), 'Cli': LeanGitRepo(url='https://github.com/mhuisi/lean4-cli', commit='5a858c32963b6b19be0d477a30a1f4b6c120be7e'), 'proofwidgets': LeanGitRepo(url='https://github.com/EdAyers/ProofWidgets4', commit='a0c2cd0ac3245a0dade4f925bcfa97e06dd84229')}, root_dir=PosixPath('/home/peiyang/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4'))\u001b[0m\n"
      ]
     }
    ],
@@ -117,7 +126,7 @@
     {
      "data": {
       "text/plain": [
-       "<networkx.classes.digraph.DiGraph at 0x7fa07ad68580>"
+       "<networkx.classes.digraph.DiGraph at 0x7fbd28a26e00>"
       ]
      },
      "execution_count": 6,
@@ -159,7 +168,7 @@
     {
      "data": {
       "text/plain": [
-       "TracedFile(root_dir=PosixPath('/raid/kaiyu/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4'), lean_file=LeanFile(path=PosixPath('Mathlib/LinearAlgebra/Basic.lean'), uses_lean4=True))"
+       "TracedFile(root_dir=PosixPath('/home/peiyang/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4'), lean_file=LeanFile(path=PosixPath('Mathlib/LinearAlgebra/Basic.lean'), uses_lean4=True))"
       ]
      },
      "execution_count": 8,
@@ -1870,7 +1879,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 21,
    "id": "f3d3f736",
    "metadata": {},
    "outputs": [
@@ -1880,7 +1889,7 @@
        "LeanGitRepo(url='https://github.com/leanprover-community/mathlib4', commit='067bc406f149a6664640db1f1a6b1e285785deff')"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1899,7 +1908,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 22,
    "id": "10364e0f",
    "metadata": {},
    "outputs": [
@@ -1907,7 +1916,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2023-08-04 08:16:28.126\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m172\u001b[0m - \u001b[33m\u001b[1mUsing Lean 4 without a hard timeout may hang indefinitely.\u001b[0m\n"
+      "\u001b[32m2023-08-09 00:40:47.977\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m172\u001b[0m - \u001b[33m\u001b[1mUsing Lean 4 without a hard timeout may hang indefinitely.\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:40:47.978\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m__enter__\u001b[0m:\u001b[36m192\u001b[0m - \u001b[34m\u001b[1mInitializing Dojo for Theorem(repo=LeanGitRepo(url='https://github.com/leanprover-community/mathlib4', commit='067bc406f149a6664640db1f1a6b1e285785deff'), file_path=PosixPath('Mathlib/LinearAlgebra/Basic.lean'), full_name='pi_eq_sum_univ')\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:40:47.979\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.trace\u001b[0m:\u001b[36mget_traced_repo_path\u001b[0m:\u001b[36m139\u001b[0m - \u001b[34m\u001b[1mThe traced repo is available in the cache.\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:41:04.312\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_modify_file\u001b[0m:\u001b[36m398\u001b[0m - \u001b[34m\u001b[1mModifying Mathlib/LinearAlgebra/Basic.lean\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:41:46.376\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m__enter__\u001b[0m:\u001b[36m225\u001b[0m - \u001b[34m\u001b[1mLaunching the proof using <class 'lean_dojo.container.DockerContainer'>\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:41:46.378\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.container\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m305\u001b[0m - \u001b[34m\u001b[1mdocker run --cidfile nwojvvss.cid --rm -u 1025 --mount type=bind,src=\"/tmp/tmpefysqh2g/mathlib4\",target=\"/workspace/mathlib4\" --workdir /workspace/mathlib4 yangky11/lean-dojo lake build Lean4Repl\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:41:58.442\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.container\u001b[0m:\u001b[36mrun_interactive\u001b[0m:\u001b[36m341\u001b[0m - \u001b[34m\u001b[1mdocker run --cidfile 7w2eev3z.cid --rm -u 1025 --mount type=bind,src=\"/tmp/tmpefysqh2g/mathlib4\",target=\"/workspace/mathlib4\" --cpus 1 --memory 16g --workdir /workspace/mathlib4 -i yangky11/lean-dojo lake env lean Mathlib/LinearAlgebra/Basic.lean\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:41:58.485\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mWARNING: Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:41:58.765\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1minfo: downloading component 'lean'\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:42:01.115\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1minfo: installing component 'lean'\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:42:07.950\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mREPL> {\"tacticState\": \"R✝ : Type ?u.41963\\nR₁ : Type ?u.41966\\nR₂ : Type ?u.41969\\nR₃ : Type ?u.41972\\nR₄ : Type ?u.41975\\nS : Type ?u.41978\\nK : Type ?u.41981\\nK₂ : Type ?u.41984\\nM : Type ?u.41987\\nM' : Type ?u.41990\\nM₁ : Type ?u.41993\\nM₂ : Type ?u.41996\\nM₃ : Type ?u.41999\\nM₄ : Type ?u.42002\\nN : Type ?u.42005\\nN₂ : Type ?u.42008\\nι✝ : Type ?u.42011\\nV : Type ?u.42014\\nV₂ : Type ?u.42017\\nι : Type u_1\\ninst✝² : Fintype ι\\ninst✝¹ : DecidableEq ι\\nR : Type u_2\\ninst✝ : Semiring R\\nx : ι → R\\n⊢ x = ∑ i : ι, x i • fun j => if i = j then 1 else 0\", \"sid\": 0, \"error\": null}\u001b[0m\n"
      ]
     }
    ],
@@ -1920,7 +1939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 23,
    "id": "a7d4ad9a",
    "metadata": {},
    "outputs": [
@@ -1930,7 +1949,7 @@
        "TacticState(pp=\"R✝ : Type ?u.41963\\nR₁ : Type ?u.41966\\nR₂ : Type ?u.41969\\nR₃ : Type ?u.41972\\nR₄ : Type ?u.41975\\nS : Type ?u.41978\\nK : Type ?u.41981\\nK₂ : Type ?u.41984\\nM : Type ?u.41987\\nM' : Type ?u.41990\\nM₁ : Type ?u.41993\\nM₂ : Type ?u.41996\\nM₃ : Type ?u.41999\\nM₄ : Type ?u.42002\\nN : Type ?u.42005\\nN₂ : Type ?u.42008\\nι✝ : Type ?u.42011\\nV : Type ?u.42014\\nV₂ : Type ?u.42017\\nι : Type u_1\\ninst✝² : Fintype ι\\ninst✝¹ : DecidableEq ι\\nR : Type u_2\\ninst✝ : Semiring R\\nx : ι → R\\n⊢ x = ∑ i : ι, x i • fun j => if i = j then 1 else 0\", id=0, message=None)"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1941,7 +1960,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 24,
    "id": "af88893b",
    "metadata": {},
    "outputs": [
@@ -1984,10 +2003,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 25,
    "id": "4ca2dca9",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2023-08-09 00:42:07.983\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_submit_request\u001b[0m:\u001b[36m547\u001b[0m - \u001b[34m\u001b[1mRequest: {\"sid\": 0, \"cmd\": \"revert x\"}\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:42:07.988\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mREPL> {\"tacticState\": \"R✝ : Type ?u.41963\\nR₁ : Type ?u.41966\\nR₂ : Type ?u.41969\\nR₃ : Type ?u.41972\\nR₄ : Type ?u.41975\\nS : Type ?u.41978\\nK : Type ?u.41981\\nK₂ : Type ?u.41984\\nM : Type ?u.41987\\nM' : Type ?u.41990\\nM₁ : Type ?u.41993\\nM₂ : Type ?u.41996\\nM₃ : Type ?u.41999\\nM₄ : Type ?u.42002\\nN : Type ?u.42005\\nN₂ : Type ?u.42008\\nι✝ : Type ?u.42011\\nV : Type ?u.42014\\nV₂ : Type ?u.42017\\nι : Type u_1\\ninst✝² : Fintype ι\\ninst✝¹ : DecidableEq ι\\nR : Type u_2\\ninst✝ : Semiring R\\n⊢ ∀ (x : ι → R), x = ∑ i : ι, x i • fun j => if i = j then 1 else 0\", \"sid\": 1, \"error\": null}\u001b[0m\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -2028,17 +2055,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 26,
    "id": "89a62c89",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2023-08-09 00:42:07.993\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_submit_request\u001b[0m:\u001b[36m547\u001b[0m - \u001b[34m\u001b[1mRequest: {\"sid\": 0, \"cmd\": \"hello world!\"}\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:42:07.994\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mREPL> {\"tacticState\": null, \"sid\": null, \"error\": \"<stdin>:1:1: unknown tactic\"}\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "LeanError(error='<stdin>:1:1: unknown tactic')"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2051,7 +2086,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 27,
    "id": "10b5f013",
    "metadata": {},
    "outputs": [
@@ -2062,7 +2097,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[41], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mdojo\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun_tac\u001b[49m\u001b[43m(\u001b[49m\u001b[43mstate_2\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mskip\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[27], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mdojo\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun_tac\u001b[49m\u001b[43m(\u001b[49m\u001b[43mstate_2\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mskip\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n",
       "File \u001b[0;32m~/LeanDojo/src/lean_dojo/interaction/dojo.py:474\u001b[0m, in \u001b[0;36mDojo.run_tac\u001b[0;34m(self, state, tactic)\u001b[0m\n\u001b[1;32m    472\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mrun_tac\u001b[39m(\u001b[38;5;28mself\u001b[39m, state: TacticState, tactic: \u001b[38;5;28mstr\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m TacticResult:\n\u001b[1;32m    473\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(state, TacticState):\n\u001b[0;32m--> 474\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mRuntimeError\u001b[39;00m(\n\u001b[1;32m    475\u001b[0m             \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mAttempting to run a tactic on an invalid state \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mstate\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m.\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    476\u001b[0m         )\n\u001b[1;32m    477\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(tactic, \u001b[38;5;28mstr\u001b[39m), \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mInvalid tactic \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mtactic\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    479\u001b[0m     tsid \u001b[38;5;241m=\u001b[39m state\u001b[38;5;241m.\u001b[39mid\n",
       "\u001b[0;31mRuntimeError\u001b[0m: Attempting to run a tactic on an invalid state LeanError(error='<stdin>:1:1: unknown tactic')."
      ]
@@ -2074,17 +2109,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 28,
    "id": "65bae6ea",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2023-08-09 00:45:36.826\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_submit_request\u001b[0m:\u001b[36m547\u001b[0m - \u001b[34m\u001b[1mRequest: {\"sid\": 0, \"cmd\": \"sorry\"}\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:45:36.833\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mREPL> {\"tacticState\": null, \"sid\": null, \"error\": \"proof contains `sorry`\"}\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "ProofGivenUp()"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2095,7 +2138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 29,
    "id": "c373865a",
    "metadata": {},
    "outputs": [
@@ -2138,10 +2181,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 30,
    "id": "a5d0156f",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2023-08-09 00:45:41.786\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_submit_request\u001b[0m:\u001b[36m547\u001b[0m - \u001b[34m\u001b[1mRequest: {\"sid\": 0, \"cmd\": \"ext\"}\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:45:41.793\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mREPL> {\"tacticState\": \"case h\\nR✝ : Type ?u.41963\\nR₁ : Type ?u.41966\\nR₂ : Type ?u.41969\\nR₃ : Type ?u.41972\\nR₄ : Type ?u.41975\\nS : Type ?u.41978\\nK : Type ?u.41981\\nK₂ : Type ?u.41984\\nM : Type ?u.41987\\nM' : Type ?u.41990\\nM₁ : Type ?u.41993\\nM₂ : Type ?u.41996\\nM₃ : Type ?u.41999\\nM₄ : Type ?u.42002\\nN : Type ?u.42005\\nN₂ : Type ?u.42008\\nι✝ : Type ?u.42011\\nV : Type ?u.42014\\nV₂ : Type ?u.42017\\nι : Type u_1\\ninst✝² : Fintype ι\\ninst✝¹ : DecidableEq ι\\nR : Type u_2\\ninst✝ : Semiring R\\nx : ι → R\\nx✝ : ι\\n⊢ x x✝ = Finset.sum Finset.univ (fun i => x i • fun j => if i = j then 1 else 0) x✝\", \"sid\": 2, \"error\": null}\u001b[0m\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -2185,10 +2236,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 31,
    "id": "71ab5854",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2023-08-09 00:45:43.058\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_submit_request\u001b[0m:\u001b[36m547\u001b[0m - \u001b[34m\u001b[1mRequest: {\"sid\": 2, \"cmd\": \"simp\"}\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:45:43.126\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mREPL> {\"tacticState\": \"no goals\", \"sid\": 3, \"error\": null}\u001b[0m\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -2205,7 +2264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 32,
    "id": "fdb44496",
    "metadata": {},
    "outputs": [
@@ -2215,7 +2274,7 @@
        "True"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2234,7 +2293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 33,
    "id": "243ea43c",
    "metadata": {},
    "outputs": [
@@ -2242,7 +2301,17 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2023-08-04 08:24:59.282\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m172\u001b[0m - \u001b[33m\u001b[1mUsing Lean 4 without a hard timeout may hang indefinitely.\u001b[0m\n"
+      "\u001b[32m2023-08-09 00:45:49.377\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m172\u001b[0m - \u001b[33m\u001b[1mUsing Lean 4 without a hard timeout may hang indefinitely.\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:45:49.378\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m__enter__\u001b[0m:\u001b[36m192\u001b[0m - \u001b[34m\u001b[1mInitializing Dojo for (LeanGitRepo(url='https://github.com/leanprover-community/mathlib4', commit='067bc406f149a6664640db1f1a6b1e285785deff'), 'Mathlib/LinearAlgebra/Basic.lean', 83)\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:45:49.379\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.trace\u001b[0m:\u001b[36mget_traced_repo_path\u001b[0m:\u001b[36m139\u001b[0m - \u001b[34m\u001b[1mThe traced repo is available in the cache.\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:46:05.526\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_modify_file\u001b[0m:\u001b[36m398\u001b[0m - \u001b[34m\u001b[1mModifying Mathlib/LinearAlgebra/Basic.lean\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:46:46.158\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m__enter__\u001b[0m:\u001b[36m225\u001b[0m - \u001b[34m\u001b[1mLaunching the proof using <class 'lean_dojo.container.DockerContainer'>\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:46:46.160\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.container\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m305\u001b[0m - \u001b[34m\u001b[1mdocker run --cidfile csl92bid.cid --rm -u 1025 --mount type=bind,src=\"/tmp/tmprch878q1/mathlib4\",target=\"/workspace/mathlib4\" --workdir /workspace/mathlib4 yangky11/lean-dojo lake build Lean4Repl\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:46:58.595\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.container\u001b[0m:\u001b[36mrun_interactive\u001b[0m:\u001b[36m341\u001b[0m - \u001b[34m\u001b[1mdocker run --cidfile kbkn61as.cid --rm -u 1025 --mount type=bind,src=\"/tmp/tmprch878q1/mathlib4\",target=\"/workspace/mathlib4\" --cpus 1 --memory 16g --workdir /workspace/mathlib4 -i yangky11/lean-dojo lake env lean Mathlib/LinearAlgebra/Basic.lean\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:46:58.640\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mWARNING: Your kernel does not support swap limit capabilities or the cgroup is not mounted. Memory limited without swap.\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:46:58.924\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1minfo: downloading component 'lean'\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:47:01.083\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1minfo: installing component 'lean'\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:47:06.999\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mREPL> {\"tacticState\": null, \"sid\": 0, \"error\": null}\u001b[0m\n"
      ]
     }
    ],
@@ -2253,7 +2322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 34,
    "id": "5ebd615c",
    "metadata": {},
    "outputs": [
@@ -2263,7 +2332,7 @@
        "CommandState(id=0, message=None)"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2274,17 +2343,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 35,
    "id": "b1e079fa",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2023-08-09 00:48:57.155\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_submit_request\u001b[0m:\u001b[36m547\u001b[0m - \u001b[34m\u001b[1mRequest: {\"sid\": 0, \"cmd\": \"#eval 1\"}\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:48:57.173\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1m1\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:48:57.174\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mREPL> {\"tacticState\": null, \"sid\": 1, \"error\": null}\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "CommandState(id=1, message='1')"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2295,17 +2373,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 36,
    "id": "31c9bada",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2023-08-09 00:49:00.633\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_submit_request\u001b[0m:\u001b[36m547\u001b[0m - \u001b[34m\u001b[1mRequest: {\"sid\": 0, \"cmd\": \"#eval x\"}\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:49:00.637\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mREPL> {\"tacticState\": null, \"sid\": 2, \"error\": \"unknown identifier 'x'\"}\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "LeanError(error=\"unknown identifier 'x'\")"
       ]
      },
-     "execution_count": 64,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2316,17 +2402,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 37,
    "id": "b638bfbf",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2023-08-09 00:49:03.549\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_submit_request\u001b[0m:\u001b[36m547\u001b[0m - \u001b[34m\u001b[1mRequest: {\"sid\": 0, \"cmd\": \"def x := 1\"}\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:49:03.555\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mREPL> {\"tacticState\": null, \"sid\": 3, \"error\": null}\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "CommandState(id=3, message='')"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2339,17 +2433,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 38,
    "id": "bdc4f14d",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2023-08-09 00:49:06.013\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_submit_request\u001b[0m:\u001b[36m547\u001b[0m - \u001b[34m\u001b[1mRequest: {\"sid\": 3, \"cmd\": \"#eval x\"}\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:49:06.030\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1m1\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:49:06.031\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mREPL> {\"tacticState\": null, \"sid\": 4, \"error\": null}\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "CommandState(id=4, message='1')"
       ]
      },
-     "execution_count": 66,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2360,17 +2463,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 39,
    "id": "ef47afb8",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2023-08-09 00:49:08.333\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_submit_request\u001b[0m:\u001b[36m547\u001b[0m - \u001b[34m\u001b[1mRequest: {\"sid\": 0, \"cmd\": \"#check smul_sum\"}\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:49:08.341\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mFinsupp.smul_sum.{u_4, u_3, u_2, u_1} {α : Type u_1} {β : Type u_2} {R : Type u_3} {M : Type u_4} [inst✝ : Zero β]\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:49:08.342\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1m[inst✝¹ : AddCommMonoid M] [inst✝² : DistribSMul R M] {v : α →₀ β} {c : R} {h : α → β → M} :\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:49:08.342\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mc • sum v h = sum v fun a b => c • h a b\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:49:08.342\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mREPL> {\"tacticState\": null, \"sid\": 5, \"error\": null}\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "CommandState(id=5, message='Finsupp.smul_sum.{u_4, u_3, u_2, u_1} {α : Type u_1} {β : Type u_2} {R : Type u_3} {M : Type u_4} [inst✝ : Zero β]\\n[inst✝¹ : AddCommMonoid M] [inst✝² : DistribSMul R M] {v : α →₀ β} {c : R} {h : α → β → M} :\\nc • sum v h = sum v fun a b => c • h a b')"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2381,17 +2495,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 40,
    "id": "c6b8b9a5",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32m2023-08-09 00:49:10.617\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_submit_request\u001b[0m:\u001b[36m547\u001b[0m - \u001b[34m\u001b[1mRequest: {\"sid\": 0, \"cmd\": \"#check sum_smul_index_linearMap'\"}\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:49:10.625\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.interaction.dojo\u001b[0m:\u001b[36m_read_next_line\u001b[0m:\u001b[36m587\u001b[0m - \u001b[34m\u001b[1mREPL> {\"tacticState\": null, \"sid\": 6, \"error\": \"unknown identifier 'sum_smul_index_linearMap''\"}\u001b[0m\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "LeanError(error=\"unknown identifier 'sum_smul_index_linearMap''\")"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2399,14 +2521,6 @@
    "source": [
     "dojo.run_cmd(state_0, \"#check sum_smul_index_linearMap'\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1670b6f0",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -2425,7 +2539,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/scripts/generate-benchmark-lean4.ipynb
+++ b/scripts/generate-benchmark-lean4.ipynb
@@ -324,30 +324,30 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2023-08-08 00:57:10.368\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.trace\u001b[0m:\u001b[36mget_traced_repo_path\u001b[0m:\u001b[36m139\u001b[0m - \u001b[34m\u001b[1mThe traced repo is available in the cache.\u001b[0m\n",
-      "\u001b[32m2023-08-08 00:57:10.369\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mlean_dojo.data_extraction.trace\u001b[0m:\u001b[36mtrace\u001b[0m:\u001b[36m163\u001b[0m - \u001b[1mLoading the traced repo from /home/peiyang/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4\u001b[0m\n",
-      "\u001b[32m2023-08-08 00:57:10.462\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.traced_data\u001b[0m:\u001b[36mload_from_disk\u001b[0m:\u001b[36m1455\u001b[0m - \u001b[34m\u001b[1mLoading 4249 traced XML files from /home/peiyang/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4 with 39 workers\u001b[0m\n",
-      "2023-08-08 00:57:12,493\tINFO worker.py:1627 -- Started a local Ray instance. View the dashboard at \u001b[1m\u001b[32m127.0.0.1:8265 \u001b[39m\u001b[22m\n",
-      "100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4249/4249 [08:02<00:00,  8.81it/s]\n",
-      "\u001b[32m2023-08-08 01:05:19.643\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/leanprover/doc-gen4 \"main\"\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:05:20.880\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/leanprover/std4 \"main\"\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:05:22.457\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/gebner/quote4 \"master\"\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:05:24.059\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/JLimperg/aesop \"master\"\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:05:25.733\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/mhuisi/lean4-cli \"nightly\"\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:05:27.443\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/EdAyers/ProofWidgets4 \"v0.0.13\"\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:05:55.040\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.traced_data\u001b[0m:\u001b[36mcheck_sanity\u001b[0m:\u001b[36m1319\u001b[0m - \u001b[34m\u001b[1mChecking the sanity of TracedRepo(repo=LeanGitRepo(url='https://github.com/leanprover-community/mathlib4', commit='067bc406f149a6664640db1f1a6b1e285785deff'), dependencies={'lean4': LeanGitRepo(url='https://github.com/leanprover/lean4', commit='125a0ba798e75fe8eb79b7ae09b25e7c760eadd5'), '«doc-gen4»': LeanGitRepo(url='https://github.com/leanprover/doc-gen4', commit='596782c1fee6e6b4a77e278f3b4f78643d1a7752'), 'std': LeanGitRepo(url='https://github.com/leanprover/std4', commit='17c3833ab170ce20fd065ae3fb550300b3d85f23'), 'Qq': LeanGitRepo(url='https://github.com/gebner/quote4', commit='81cc13c524a68d0072561dbac276cd61b65872a6'), 'aesop': LeanGitRepo(url='https://github.com/JLimperg/aesop', commit='354432d437fb37738ed93ac6988669d78a870ed0'), 'Cli': LeanGitRepo(url='https://github.com/mhuisi/lean4-cli', commit='5a858c32963b6b19be0d477a30a1f4b6c120be7e'), 'proofwidgets': LeanGitRepo(url='https://github.com/EdAyers/ProofWidgets4', commit='a0c2cd0ac3245a0dade4f925bcfa97e06dd84229')}, root_dir=PosixPath('/home/peiyang/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4'))\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:06:14.148\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36msplit_data\u001b[0m:\u001b[36m3\u001b[0m - \u001b[1m101315 theorems in total\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:06:14.150\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36msplit_randomly\u001b[0m:\u001b[36m18\u001b[0m - \u001b[1mSplitting the theorems randomly\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:06:14.191\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36msplit_by_premise\u001b[0m:\u001b[36m8\u001b[0m - \u001b[1mSplitting the theorems by premises\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:06:24.428\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m11\u001b[0m - \u001b[33m\u001b[1m../leandojo_benchmark_4 already exists. Removing it now.\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:10:38.957\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m97315 theorems and 200774 tactics saved to ../leandojo_benchmark_4/random/train.json\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:10:43.371\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 3888 tactics saved to ../leandojo_benchmark_4/random/val.json\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:10:48.956\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 4134 tactics saved to ../leandojo_benchmark_4/random/test.json\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:14:25.751\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m97315 theorems and 184754 tactics saved to ../leandojo_benchmark_4/novel_premises/train.json\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:14:45.897\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 11722 tactics saved to ../leandojo_benchmark_4/novel_premises/val.json\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:15:07.538\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 12320 tactics saved to ../leandojo_benchmark_4/novel_premises/test.json\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:15:27.982\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m71\u001b[0m - \u001b[1m101315 theorems/definitions from 4249 files saved to ../leandojo_benchmark_4/corpus.jsonl\u001b[0m\n",
-      "\u001b[32m2023-08-08 01:15:29.337\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.utils\u001b[0m:\u001b[36mread_url\u001b[0m:\u001b[36m238\u001b[0m - \u001b[34m\u001b[1mRequset to https://raw.githubusercontent.com/gebner/quote4/81cc13c524a68d0072561dbac276cd61b65872a6/LICENSE failed. Retrying...\u001b[0m\n"
+      "\u001b[32m2023-08-09 00:16:36.876\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.trace\u001b[0m:\u001b[36mget_traced_repo_path\u001b[0m:\u001b[36m139\u001b[0m - \u001b[34m\u001b[1mThe traced repo is available in the cache.\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:16:36.877\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mlean_dojo.data_extraction.trace\u001b[0m:\u001b[36mtrace\u001b[0m:\u001b[36m163\u001b[0m - \u001b[1mLoading the traced repo from /home/peiyang/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:16:36.972\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.traced_data\u001b[0m:\u001b[36mload_from_disk\u001b[0m:\u001b[36m1458\u001b[0m - \u001b[34m\u001b[1mLoading 4249 traced XML files from /home/peiyang/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4 with 39 workers\u001b[0m\n",
+      "2023-08-09 00:16:38,987\tINFO worker.py:1627 -- Started a local Ray instance. View the dashboard at \u001b[1m\u001b[32m127.0.0.1:8265 \u001b[39m\u001b[22m\n",
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4249/4249 [07:16<00:00,  9.74it/s]\n",
+      "\u001b[32m2023-08-09 00:24:00.185\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/leanprover/doc-gen4 \"main\"\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:24:01.722\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/leanprover/std4 \"main\"\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:24:03.850\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/gebner/quote4 \"master\"\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:24:05.476\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/JLimperg/aesop \"master\"\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:24:06.961\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/mhuisi/lean4-cli \"nightly\"\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:24:08.658\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.lean\u001b[0m:\u001b[36m_parse_lakefile_dependencies\u001b[0m:\u001b[36m499\u001b[0m - \u001b[34m\u001b[1mQuerying the commit hash for https://github.com/EdAyers/ProofWidgets4 \"v0.0.13\"\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:24:36.737\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.data_extraction.traced_data\u001b[0m:\u001b[36mcheck_sanity\u001b[0m:\u001b[36m1322\u001b[0m - \u001b[34m\u001b[1mChecking the sanity of TracedRepo(repo=LeanGitRepo(url='https://github.com/leanprover-community/mathlib4', commit='067bc406f149a6664640db1f1a6b1e285785deff'), dependencies={'lean4': LeanGitRepo(url='https://github.com/leanprover/lean4', commit='125a0ba798e75fe8eb79b7ae09b25e7c760eadd5'), '«doc-gen4»': LeanGitRepo(url='https://github.com/leanprover/doc-gen4', commit='596782c1fee6e6b4a77e278f3b4f78643d1a7752'), 'std': LeanGitRepo(url='https://github.com/leanprover/std4', commit='17c3833ab170ce20fd065ae3fb550300b3d85f23'), 'Qq': LeanGitRepo(url='https://github.com/gebner/quote4', commit='81cc13c524a68d0072561dbac276cd61b65872a6'), 'aesop': LeanGitRepo(url='https://github.com/JLimperg/aesop', commit='354432d437fb37738ed93ac6988669d78a870ed0'), 'Cli': LeanGitRepo(url='https://github.com/mhuisi/lean4-cli', commit='5a858c32963b6b19be0d477a30a1f4b6c120be7e'), 'proofwidgets': LeanGitRepo(url='https://github.com/EdAyers/ProofWidgets4', commit='a0c2cd0ac3245a0dade4f925bcfa97e06dd84229')}, root_dir=PosixPath('/home/peiyang/.cache/lean_dojo/leanprover-community-mathlib4-067bc406f149a6664640db1f1a6b1e285785deff/mathlib4'))\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:24:54.375\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36msplit_data\u001b[0m:\u001b[36m3\u001b[0m - \u001b[1m101315 theorems in total\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:24:54.377\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36msplit_randomly\u001b[0m:\u001b[36m18\u001b[0m - \u001b[1mSplitting the theorems randomly\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:24:54.455\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36msplit_by_premise\u001b[0m:\u001b[36m8\u001b[0m - \u001b[1mSplitting the theorems by premises\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:25:03.332\u001b[0m | \u001b[33m\u001b[1mWARNING \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m11\u001b[0m - \u001b[33m\u001b[1m../leandojo_benchmark_4 already exists. Removing it now.\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:27:27.190\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m97315 theorems and 200493 tactics saved to ../leandojo_benchmark_4/random/train.json\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:27:30.203\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 4129 tactics saved to ../leandojo_benchmark_4/random/val.json\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:27:32.889\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 4174 tactics saved to ../leandojo_benchmark_4/random/test.json\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:29:30.739\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m97315 theorems and 184892 tactics saved to ../leandojo_benchmark_4/novel_premises/train.json\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:29:44.727\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 12076 tactics saved to ../leandojo_benchmark_4/novel_premises/val.json\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:29:57.965\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m51\u001b[0m - \u001b[1m2000 theorems and 11828 tactics saved to ../leandojo_benchmark_4/novel_premises/test.json\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:30:17.302\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36m__main__\u001b[0m:\u001b[36mexport_data\u001b[0m:\u001b[36m71\u001b[0m - \u001b[1m101315 theorems/definitions from 4249 files saved to ../leandojo_benchmark_4/corpus.jsonl\u001b[0m\n",
+      "\u001b[32m2023-08-09 00:30:19.068\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mlean_dojo.utils\u001b[0m:\u001b[36mread_url\u001b[0m:\u001b[36m238\u001b[0m - \u001b[34m\u001b[1mRequset to https://raw.githubusercontent.com/gebner/quote4/81cc13c524a68d0072561dbac276cd61b65872a6/LICENSE failed. Retrying...\u001b[0m\n"
      ]
     }
    ],
@@ -423,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 18,
    "id": "cbca21c9",
    "metadata": {},
    "outputs": [
@@ -433,7 +433,7 @@
        "dict_keys(['path', 'imports', 'premises'])"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -455,20 +455,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 19,
    "id": "f5c1920a",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "('Mathlib/Order/Hom/Lattice.lean',\n",
-       " ['Mathlib/Order/SymmDiff.lean',\n",
-       "  'lake-packages/lean4/src/lean/Init.lean',\n",
-       "  'Mathlib/Order/Hom/Bounded.lean'])"
+       "('Mathlib/Order/ULift.lean',\n",
+       " ['lake-packages/lean4/src/lean/Init.lean', 'Mathlib/Order/Basic.lean'])"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -479,17 +477,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 20,
    "id": "d801a0ae",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "165"
+       "14"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -508,21 +506,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 21,
    "id": "b533d342",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'full_name': 'Disjoint.map',\n",
-       " 'code': 'theorem Disjoint.map (h : Disjoint a b) : Disjoint (f a) (f b)',\n",
-       " 'start': [266, 1],\n",
-       " 'end': [267, 50],\n",
+       "{'full_name': 'ULift.up_le',\n",
+       " 'code': 'theorem up_le [LE α] {a b : α} : up a ≤ up b ↔ a ≤ b',\n",
+       " 'start': [22, 9],\n",
+       " 'end': [22, 72],\n",
        " 'kind': 'commandtheoremn'}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -546,7 +544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 22,
    "id": "4fb19aa3",
    "metadata": {},
    "outputs": [
@@ -556,7 +554,7 @@
        "96637"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -577,7 +575,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 23,
    "id": "3cc47f7e",
    "metadata": {},
    "outputs": [
@@ -587,7 +585,7 @@
        "dict_keys(['url', 'commit', 'file_path', 'full_name', 'start', 'end', 'traced_tactics'])"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -601,7 +599,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 24,
    "id": "3c2c36a7",
    "metadata": {},
    "outputs": [
@@ -610,11 +608,11 @@
       "text/plain": [
        "('https://github.com/leanprover-community/mathlib4',\n",
        " '067bc406f149a6664640db1f1a6b1e285785deff',\n",
-       " 'Mathlib/GroupTheory/Subgroup/Pointwise.lean',\n",
-       " 'Subgroup.sup_eq_closure')"
+       " 'Mathlib/Topology/ContinuousFunction/Bounded.lean',\n",
+       " 'BoundedContinuousFunction.norm_coe_le_norm')"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -633,7 +631,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 25,
    "id": "c29987ff",
    "metadata": {},
    "outputs": [
@@ -643,7 +641,7 @@
        "1"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -662,20 +660,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 26,
    "id": "a734d788",
    "metadata": {},
    "outputs": [
     {
-     "ename": "IndexError",
-     "evalue": "list index out of range",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[17], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mproof\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mtraced_tactics\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m9\u001b[39;49m\u001b[43m]\u001b[49m\n",
-      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
-     ]
+     "data": {
+      "text/plain": [
+       "{'tactic': 'simp [dist_zero_right]',\n",
+       " 'annotated_tactic': ['simp [<a>dist_zero_right</a>]',\n",
+       "  [{'full_name': 'dist_zero_right',\n",
+       "    'def_path': 'Mathlib/Analysis/Normed/Group/Basic.lean',\n",
+       "    'def_pos': [395, 3],\n",
+       "    'def_end_pos': [395, 14]}]],\n",
+       " 'state_before': 'F : Type ?u.1072182\\nα : Type u\\nβ : Type v\\nγ : Type w\\ninst✝¹ : TopologicalSpace α\\ninst✝ : SeminormedAddCommGroup β\\nf g : α →ᵇ β\\nx✝ : α\\nC : ℝ\\nx : α\\n⊢ ‖↑f x‖ = dist (↑f x) (↑0 x)',\n",
+       " 'state_after': 'no goals'}"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [

--- a/src/lean_dojo/data_extraction/ExtractData.lean
+++ b/src/lean_dojo/data_extraction/ExtractData.lean
@@ -184,6 +184,7 @@ def toSrcDir (path : FilePath) (ext : String) : Option FilePath :=
       let comps := p.components
       assert! comps[1]! == "build"
       match comps with
+      | t0 :: "build" :: "lib" :: t1 => mkFilePath $ "lake-packages" :: t0 :: t1
       | _ :: _ :: _ :: tl => mkFilePath tl
       | _ => "invalid path"
     | none =>

--- a/src/lean_dojo/data_extraction/traced_data.py
+++ b/src/lean_dojo/data_extraction/traced_data.py
@@ -259,24 +259,25 @@ class TracedTactic:
                         )
                         prov = {"full_name": node.full_name}
                         def_path = (node.mod_name).replace(".", "/") + ".lean"
-                        prov["def_path"] = def_path
-                        if self.traced_theorem is not None and self.traced_theorem.traced_repo is not None:
-                            graph = self.traced_theorem.traced_repo.traced_files_graph
-                            start_node = str(self.traced_theorem.traced_file.path)
-                            assert graph.has_node(start_node)
-                            def bfs(start_node: str) -> str:
-                                visited_nodes = set()
-                                queue = deque([start_node])
-                                while queue:
-                                    curr_node = queue.popleft()
-                                    visited_nodes.add(curr_node)
-                                    if curr_node.endswith(def_path):
-                                        return curr_node
-                                    for next_node in graph.successors(curr_node):
-                                        if next_node not in visited_nodes:
-                                            queue.append(next_node)
-                                return None
-                            prov["def_path"] = bfs(start_node)
+                        assert self.traced_theorem is not None 
+                        assert self.traced_theorem.traced_repo is not None
+                        graph = self.traced_theorem.traced_repo.traced_files_graph
+                        start_node = str(self.traced_theorem.traced_file.path)
+                        assert graph.has_node(start_node)
+                        def bfs(start_node: str) -> str:
+                            visited_nodes = set()
+                            queue = deque([start_node])
+                            while queue:
+                                curr_node = queue.popleft()
+                                visited_nodes.add(curr_node)
+                                if curr_node.endswith(def_path):
+                                    return curr_node
+                                for next_node in graph.successors(curr_node):
+                                    if next_node not in visited_nodes:
+                                        queue.append(next_node)
+                            return None
+                        prov["def_path"] = bfs(start_node)
+                        assert prov["def_path"] is not None, f"Unable to locate {node.full_name}"
                         prov["def_pos"] = list(node.def_start)
                         prov["def_end_pos"] = list(node.def_end)
                         provenances.append(prov)
@@ -1233,8 +1234,8 @@ def _build_dependency_graph(traced_files: List[TracedFile]) -> nx.DiGraph:
         tf_path_str = str(tf.path)
         for dep_path in tf.get_direct_dependencies():
             dep_path_str = str(dep_path)
-            if G.has_node(dep_path_str):
-                G.add_edge(tf_path_str, dep_path_str)
+            assert G.has_node(dep_path_str)
+            G.add_edge(tf_path_str, dep_path_str)
 
     assert nx.is_directed_acyclic_graph(G)
     return G


### PR DESCRIPTION
## Fix known bugs related to dependency graph building

This pull request addresses the known bug that dependency graph does not contain external library files (e.g., `Std`). 

- This PR modifies `ExtractData.lean` to produce an improved version of `.dep_paths` files where all module paths are relative to the repo head, including those from external libraries.

- For development purpose, this PR changed the "if" statement in the `build_dependency_graph` method to assertion. This PR currently keeps this modification, because we believe all the edges we are attempting to add should indeed be able to be added. We cannot think of a case that this "add-edge" can be expected to fail.

- This PR has been tested by tracing the whole `Mathlib4`. Both Lean4-related `.ipython` notebooks are updated. Please refer to their contents for results.

- **Important**: This PR generates a newer version of benchmark4, which calls to update the remote cache.
