### PR TITLE
Faster recursive loading of indexed content

### DIFF
--- a/src/lean_dojo/constants.py
+++ b/src/lean_dojo/constants.py
@@ -83,6 +83,9 @@ LEAN4_NIGHTLY_REPO = GITHUB.get_repo("leanprover/lean4-nightly")
 LEAN4_DEPS_DIR = Path("lake-packages")
 """The directory where Lean 4 dependencies are stored."""
 
+LOAD_TRACED_DEPENDENCIES_RECURSIVELY = bool(os.getenv("LOAD_TRACED_DEPENDENCIES_RECURSIVELY", False))
+"""Whether to load traced dependencies recursively."""
+
 TACTIC_TIMEOUT = int(os.getenv("TACTIC_TIMEOUT", 5000))
 """Maximum time (in milliseconds) before interrupting a tactic when interacting with Lean (only for Lean 3).
 """

--- a/src/lean_dojo/constants.py
+++ b/src/lean_dojo/constants.py
@@ -83,7 +83,9 @@ LEAN4_NIGHTLY_REPO = GITHUB.get_repo("leanprover/lean4-nightly")
 LEAN4_DEPS_DIR = Path("lake-packages")
 """The directory where Lean 4 dependencies are stored."""
 
-LOAD_TRACED_DEPENDENCIES_RECURSIVELY = bool(os.getenv("LOAD_TRACED_DEPENDENCIES_RECURSIVELY", False))
+LOAD_TRACED_DEPENDENCIES_RECURSIVELY = bool(
+    os.getenv("LOAD_TRACED_DEPENDENCIES_RECURSIVELY", False)
+)
 """Whether to load traced dependencies recursively."""
 
 TACTIC_TIMEOUT = int(os.getenv("TACTIC_TIMEOUT", 5000))

--- a/src/lean_dojo/data_extraction/traced_data.py
+++ b/src/lean_dojo/data_extraction/traced_data.py
@@ -1231,7 +1231,9 @@ def _save_xml_to_disk(tf: TracedFile) -> None:
         oup.write(tf.to_xml())
 
 
-def _build_dependency_graph(traced_files: List[TracedFile], root_dir: Path, repo: LeanGitRepo) -> nx.DiGraph:
+def _build_dependency_graph(
+    traced_files: List[TracedFile], root_dir: Path, repo: LeanGitRepo
+) -> nx.DiGraph:
     G = nx.DiGraph()
 
     for tf in traced_files:
@@ -1244,9 +1246,11 @@ def _build_dependency_graph(traced_files: List[TracedFile], root_dir: Path, repo
         for dep_path in tf.get_direct_dependencies():
             dep_path_str = str(dep_path)
             if not G.has_node(dep_path_str):
-                xml_to_index = (str(root_dir) + "/" + dep_path_str.replace("/src/", "/lib/")).replace(".lean", ".trace.xml")
+                xml_to_index = (
+                    str(root_dir) + "/" + dep_path_str.replace("/src/", "/lib/")
+                ).replace(".lean", ".trace.xml")
                 new_traced_file = TracedFile.from_xml(root_dir, xml_to_index, repo)
-                G.add_node(str(new_traced_file.path), traced_file=new_traced_file) 
+                G.add_node(str(new_traced_file.path), traced_file=new_traced_file)
             G.add_edge(tf_path_str, dep_path_str)
 
     assert nx.is_directed_acyclic_graph(G)
@@ -1472,7 +1476,11 @@ class TracedRepo:
 
         # exclude all imported lake-packages
         if LOAD_TRACED_DEPENDENCIES_RECURSIVELY:
-            xml_paths = [xml_path for xml_path in xml_paths if not "lake-packages" in str(xml_path)]
+            xml_paths = [
+                xml_path
+                for xml_path in xml_paths
+                if not "lake-packages" in str(xml_path)
+            ]
 
         if NUM_WORKERS <= 1:
             traced_files = [

--- a/src/lean_dojo/data_extraction/traced_data.py
+++ b/src/lean_dojo/data_extraction/traced_data.py
@@ -17,6 +17,9 @@ from datetime import datetime
 from dataclasses import dataclass, field
 from typing import List, Optional, Dict, Any, Tuple, Generator, Union
 
+from ..constants import (
+    LOAD_TRACED_DEPENDENCIES_RECURSIVELY,
+)
 from ..utils import (
     is_git_repo,
     compute_md5,
@@ -1228,7 +1231,7 @@ def _save_xml_to_disk(tf: TracedFile) -> None:
         oup.write(tf.to_xml())
 
 
-def _build_dependency_graph(traced_files: List[TracedFile]) -> nx.DiGraph:
+def _build_dependency_graph(traced_files: List[TracedFile], root_dir: Path, repo: LeanGitRepo) -> nx.DiGraph:
     G = nx.DiGraph()
 
     for tf in traced_files:
@@ -1240,7 +1243,10 @@ def _build_dependency_graph(traced_files: List[TracedFile]) -> nx.DiGraph:
         tf_path_str = str(tf.path)
         for dep_path in tf.get_direct_dependencies():
             dep_path_str = str(dep_path)
-            assert G.has_node(dep_path_str)
+            if not G.has_node(dep_path_str):
+                xml_to_index = (str(root_dir) + "/" + dep_path_str.replace("/src/", "/lib/")).replace(".lean", ".trace.xml")
+                new_traced_file = TracedFile.from_xml(root_dir, xml_to_index, repo)
+                G.add_node(str(new_traced_file.path), traced_file=new_traced_file) 
             G.add_edge(tf_path_str, dep_path_str)
 
     assert nx.is_directed_acyclic_graph(G)
@@ -1347,7 +1353,8 @@ class TracedRepo:
             p.relative_to(self.root_dir) for p in self.root_dir.glob("**/*.dep_paths")
         }
 
-        assert len(json_files) == self.traced_files_graph.number_of_nodes()
+        if not LOAD_TRACED_DEPENDENCIES_RECURSIVELY:
+            assert len(json_files) == self.traced_files_graph.number_of_nodes()
 
         for path_str, tf_node in self.traced_files_graph.nodes.items():
             tf = tf_node["traced_file"]
@@ -1406,7 +1413,7 @@ class TracedRepo:
                 )
 
         dependencies = repo.get_dependencies(root_dir)
-        traced_files_graph = _build_dependency_graph(traced_files)
+        traced_files_graph = _build_dependency_graph(traced_files, root_dir, repo)
         traced_repo = cls(repo, dependencies, root_dir, traced_files_graph)
         traced_repo._update_traced_files()
         return traced_repo
@@ -1463,6 +1470,10 @@ class TracedRepo:
             f"Loading {len(xml_paths)} traced XML files from {root_dir} with {NUM_WORKERS} workers"
         )
 
+        # exclude all imported lake-packages
+        if LOAD_TRACED_DEPENDENCIES_RECURSIVELY:
+            xml_paths = [xml_path for xml_path in xml_paths if not "lake-packages" in str(xml_path)]
+
         if NUM_WORKERS <= 1:
             traced_files = [
                 TracedFile.from_xml(root_dir, path, repo) for path in tqdm(xml_paths)
@@ -1479,7 +1490,7 @@ class TracedRepo:
                 )
 
         dependencies = repo.get_dependencies(root_dir)
-        traced_files_graph = _build_dependency_graph(traced_files)
+        traced_files_graph = _build_dependency_graph(traced_files, root_dir, repo)
         traced_repo = cls(repo, dependencies, root_dir, traced_files_graph)
         traced_repo._update_traced_files()
         return traced_repo


### PR DESCRIPTION
Currently, loading traced repos ( by running  TracedRepo.load_from_disk)  of simple repos like the https://github.com/yangky11/lean4-example takes quite some time on my machine. 

I reduced the time by a factor of nearly 10x by loading only the needed traced files. This means we first only read the traced files of the main repo and then only the traced libraries that we really depend on when building the dependency graph.

This PR is quite important for me as it allows me to iterate much quicker on the code, as simple tests take much shorter. If we use the same tracing technique, then the unit tests would run on small machines at reasonable times. But this is for a future PR.

Since this recursive loading is not guaranteed to be faster(it's not so easy to parallelize), I put the recursive loading behind a FLAG.