### PR TITLE
Collets level params in more cases

### DIFF
--- a/src/lean_dojo/interaction/Lean4Repl.lean
+++ b/src/lean_dojo/interaction/Lean4Repl.lean
@@ -113,8 +113,17 @@ private def levels2Names : List Level → NameSet
   | _ :: us => levels2Names us
 
 
+def collectFromLevel : Level → NameSet
+| Level.zero => NameSet.empty
+| Level.succ l => collectFromLevel l
+| Level.param n => NameSet.empty.insert n
+| Level.max l1 l2 => (collectFromLevel l1).union $ collectFromLevel l2
+| Level.imax l1 l2 => (collectFromLevel l1).union $ collectFromLevel l2
+| Level.mvar _ => NameSet.empty
+
+
 private def collectLevelParams : Expr → NameSet
-  | .sort (Level.param n) => NameSet.empty.insert n
+  | .sort u => collectFromLevel u
   | .const _ us => levels2Names us
   | .app fm arg => (collectLevelParams fm).union $ collectLevelParams arg
   | .lam _ binderType body _ => (collectLevelParams binderType).union $ collectLevelParams body


### PR DESCRIPTION
Small modification to collect the level params in more cases. 

This eliminates some errors in simulations via the Repl. E.g. the simulation of the following theorem:
```
theorem exists_not_acc_lt_of_not_acc {a : α} {r} (h : ¬Acc r a) : ∃ b, ¬Acc r b ∧ r b a := by
  contrapose! h
  refine' ⟨_, fun b hr => _⟩
  by_contra hb
  exact h b hb hr
#align rel_embedding.exists_not_acc_lt_of_not_acc RelEmbedding.exists_not_acc_lt_of_not_acc
```

would throw an error that a level param does not exist.