### PR TITLE
Do not list the theorem itself as premise

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -16,7 +16,7 @@ Requirements
 * get
 * `elan <https://github.com/leanprover/elan>`_
 * `Docker <https://www.docker.com/>`_ strongly recommended when using LeanDojo with Lean 3. See :ref:`running-within-docker` if it is not an option for you
-
+* Recommended: Generate a `GitHub personal access token <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#personal-access-tokens-classic>`_ and set the environment variable :code:`GITHUB_ACCESS_TOKEN` to it
 
 Installation
 ************

--- a/src/lean_dojo/data_extraction/ExtractData.lean
+++ b/src/lean_dojo/data_extraction/ExtractData.lean
@@ -303,7 +303,7 @@ private def visitTermInfo (ti : TermInfo) (env : Environment) : TraceM Unit := d
   let defPos := decRanges >>= fun (decR : DeclarationRanges) => decR.selectionRange.pos
   let defEndPos := decRanges >>= fun (decR : DeclarationRanges) => decR.selectionRange.endPos
 
-  if defPos != posBefore && defEndPos != posAfter then
+  if defPos != posBefore && defEndPos != posAfter then /- Don't include defintions as premises. -/
     modify fun trace => {
         trace with premises := trace.premises.push {
           fullName := toString fullName,

--- a/src/lean_dojo/data_extraction/ExtractData.lean
+++ b/src/lean_dojo/data_extraction/ExtractData.lean
@@ -303,16 +303,17 @@ private def visitTermInfo (ti : TermInfo) (env : Environment) : TraceM Unit := d
   let defPos := decRanges >>= fun (decR : DeclarationRanges) => decR.selectionRange.pos
   let defEndPos := decRanges >>= fun (decR : DeclarationRanges) => decR.selectionRange.endPos
 
-  modify fun trace => {
-      trace with premises := trace.premises.push {
-        fullName := toString fullName,
-        defPos := defPos,
-        defEndPos := defEndPos,
-        pos := posBefore,
-        endPos := posAfter,
-        modName := toString modName,
+  if defPos != posBefore && defEndPos != posAfter then
+    modify fun trace => {
+        trace with premises := trace.premises.push {
+          fullName := toString fullName,
+          defPos := defPos,
+          defEndPos := defEndPos,
+          pos := posBefore,
+          endPos := posAfter,
+          modName := toString modName,
+        }
       }
-    }
 
 
 private def visitInfo (ctx : ContextInfo) (i : Info) (parent : InfoTree) (env : Environment) : TraceM Unit := do


### PR DESCRIPTION
WIth the lastest modifications, we are listing the theorem itself as a premise to the theorem itself.

This is because the ExtractData script visits a  def/theorem itself within visitTermInfo while parsing. 

