### PR TITLE
fix #118

### DIFF
--- a/src/lean_dojo/data_extraction/build_lean4_repo.py
+++ b/src/lean_dojo/data_extraction/build_lean4_repo.py
@@ -134,7 +134,9 @@ def is_new_version(v) -> bool:
     assert major == 4 and minor == 3 and patch == 0
     if "4.3.0-rc" in v:
         rc = int(v.split("-")[1][2:])
-    return rc >= 2
+        return rc >= 2
+    else:
+        return True
 
 
 def main() -> None:


### PR DESCRIPTION
version "4.3.0" (without rc*x*) will be considered new.