### PR TITLE
Tiny change to support Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ description = "LeanDojo: Machine Learning for Theorem Proving in Lean"
 keywords = ["theorem proving", "machine learning", "Lean"]
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.9,<3.11"  # https://docs.ray.io/en/latest/ray-overview/installation.html#daily-releases-nightlies
+requires-python = ">=3.9,<3.12"  # https://docs.ray.io/en/latest/ray-overview/installation.html#daily-releases-nightlies
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Hi, thanks for this helpful library!

Python 3.11 has been around for a while, and many libraries such as PyTorch already supports it. When install LeanDojo it rejects 3.11, and I checked the link https://docs.ray.io/en/latest/ray-overview/installation.html#daily-releases-nightlies given by the comments, which says Ray (experimentally) supports 3.11. Therefore, I wonder why LeanDojo forbids 3.11 - is it because there are some known Ray bugs that will occur in LeanDojo (then this PR should definitely be rejected), or because 3.11 was not supported by Ray long ago but now things has changed?