### PR TITLE
Minor fix to remove CI node warning

### DIFF
--- a/.github/workflows/format_code.yaml
+++ b/.github/workflows/format_code.yaml
@@ -4,7 +4,7 @@ jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
           options: "--check --diff"

--- a/.github/workflows/type_check.yaml
+++ b/.github/workflows/type_check.yaml
@@ -7,7 +7,7 @@ jobs:
   types:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python 3.10
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
This removes the warning message from CI runs: 

```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2.
For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/.
```

(tested)