### PR TITLE
Use `pexpect` instead of `signal` in dojo.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath("../../src/lean_dojo/"))
 project = "LeanDojo"
 copyright = "2023, LeanDojo Team"
 author = "Kaiyu Yang"
-release = "2.0.0"
+release = "2.0.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,6 @@ pretty = True
 implicit_reexport = True
 disallow_untyped_calls = False
 follow_imports = skip
+
+[mypy-pexpect.*]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ exclude = [
 
 [project]
 name = "lean-dojo"
-version = "2.0.0"
+version = "2.0.1"
 authors = [
   { name="Kaiyu Yang", email="kaiyuy@meta.com" },
 ]
@@ -32,6 +32,7 @@ dependencies = [
   "loguru",
   "filelock",
   "psutil",
+  "pexpect",
   "types-psutil",
   "tqdm",
   "toml",

--- a/src/lean_dojo/__init__.py
+++ b/src/lean_dojo/__init__.py
@@ -19,7 +19,7 @@ from .interaction.dojo import (
     TimeoutError,
     TacticResult,
     DojoCrashError,
-    DojoHardTimeoutError,
+    DojoTacticTimeoutError,
     DojoInitError,
     Dojo,
     ProofFinished,

--- a/src/lean_dojo/constants.py
+++ b/src/lean_dojo/constants.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 logger.remove()
 if "VERBOSE" in os.environ or "DEBUG" in os.environ:

--- a/tests/interaction/test_timeout.py
+++ b/tests/interaction/test_timeout.py
@@ -9,6 +9,6 @@ def test_timeout_1(lean4_example_repo: LeanGitRepo) -> None:
         "Lean4Example.lean",
         "hello_world",
     )
-    with Dojo(thm, hard_timeout=10) as (dojo, init_state):
-        with pytest.raises(DojoHardTimeoutError):
+    with Dojo(thm) as (dojo, init_state):
+        with pytest.raises(DojoTacticTimeoutError):
             dojo.run_tac(init_state, "sleep 99999999999999")


### PR DESCRIPTION
This is to work around the limitation that `signal` can only be used in the main thread.