### PR TITLE
Extend function features to allow new repo types

### DIFF
--- a/src/lean_dojo/data_extraction/cache.py
+++ b/src/lean_dojo/data_extraction/cache.py
@@ -90,10 +90,12 @@ class Cache:
             else:
                 return None
 
-    def store(self, src: Path) -> Path:
+    def store(self, src: Path, fmt_name: str = "") -> Path:
         """Store a traced repo at path ``src``. Return its path in the cache."""
         url, commit = get_repo_info(src)
-        dirpath = self.cache_dir / _format_dirname(url, commit)
+        if fmt_name == "":  # if not specified, extract from the traced repo
+            fmt_name = _format_dirname(url, commit)
+        dirpath = self.cache_dir / fmt_name
         _, repo_name = _split_git_url(url)
         if not dirpath.exists():
             with self.lock:

--- a/src/lean_dojo/data_extraction/lean.py
+++ b/src/lean_dojo/data_extraction/lean.py
@@ -427,9 +427,14 @@ class LeanGitRepo:
             lean_version = self.commit
         else:
             config = self.get_config("lean-toolchain")
-            lean_version = get_lean4_commit_from_config(config)
-            v = get_lean4_version_from_config(config["content"])
-            if not is_supported_version(v):
+            toolchain = config["content"]
+            m = _LEAN4_VERSION_REGEX.fullmatch(toolchain.strip())
+            if m is not None:
+                lean_version = m["version"]
+            else:
+                # lean_version_commit = get_lean4_commit_from_config(config)
+                lean_version = get_lean4_version_from_config(toolchain)
+            if not is_supported_version(lean_version):
                 logger.warning(
                     f"{self} relies on an unsupported Lean version: {lean_version}"
                 )

--- a/src/lean_dojo/data_extraction/trace.py
+++ b/src/lean_dojo/data_extraction/trace.py
@@ -212,7 +212,7 @@ def get_traced_repo_path(repo: LeanGitRepo, build_deps: bool = True) -> Path:
             _trace(repo, build_deps)
             traced_repo = TracedRepo.from_traced_files(tmp_dir / repo.name, build_deps)
             traced_repo.save_to_disk()
-            path = cache.store(tmp_dir / repo.name)
+            path = cache.store(tmp_dir / repo.name, repo.format_dirname)
     else:
         logger.debug("The traced repo is available in the cache.")
     return path

--- a/src/lean_dojo/data_extraction/trace.py
+++ b/src/lean_dojo/data_extraction/trace.py
@@ -212,7 +212,9 @@ def get_traced_repo_path(repo: LeanGitRepo, build_deps: bool = True) -> Path:
             _trace(repo, build_deps)
             traced_repo = TracedRepo.from_traced_files(tmp_dir / repo.name, build_deps)
             traced_repo.save_to_disk()
-            path = cache.store(tmp_dir / repo.name, repo.format_dirname)
+            src_dir = tmp_dir / repo.name
+            rel_cache_dir = Path(repo.format_dirname / repo.name)
+            path = cache.store(src_dir, rel_cache_dir)
     else:
         logger.debug("The traced repo is available in the cache.")
     return path

--- a/src/lean_dojo/data_extraction/trace.py
+++ b/src/lean_dojo/data_extraction/trace.py
@@ -213,7 +213,7 @@ def get_traced_repo_path(repo: LeanGitRepo, build_deps: bool = True) -> Path:
             traced_repo = TracedRepo.from_traced_files(tmp_dir / repo.name, build_deps)
             traced_repo.save_to_disk()
             src_dir = tmp_dir / repo.name
-            rel_cache_dir = Path(repo.format_dirname / repo.name)
+            rel_cache_dir = Path(repo.format_dirname) / repo.name
             path = cache.store(src_dir, rel_cache_dir)
     else:
         logger.debug("The traced repo is available in the cache.")

--- a/src/lean_dojo/utils.py
+++ b/src/lean_dojo/utils.py
@@ -16,7 +16,6 @@ from functools import cache
 from contextlib import contextmanager
 from ray.util.actor_pool import ActorPool
 from typing import Tuple, Union, List, Generator, Optional
-from urllib.parse import urlparse
 
 from .constants import NUM_WORKERS, TMP_DIR, LEAN4_PACKAGES_DIR, LEAN4_BUILD_DIR
 
@@ -143,33 +142,6 @@ _CAMEL_CASE_REGEX = re.compile(r"(_|-)+")
 def camel_case(s: str) -> str:
     """Convert the string ``s`` to camel case."""
     return _CAMEL_CASE_REGEX.sub(" ", s).title().replace(" ", "")
-
-
-def repo_type_of_url(url: str) -> Union[str, None]:
-    """Get the type of the repository.
-
-    Args:
-        url (str): The URL of the repository.
-    Returns:
-        str: The type of the repository.
-    """
-    parsed_url = urlparse(url)
-    if parsed_url.scheme in ["http", "https"]:
-        # case 1 - GitHub URL
-        if "github.com" in url:
-            if not url.startswith("https://"):
-                logger.warning(f"{url} should start with https://")
-                return
-            else:
-                return "github"
-        # case 2 - remote URL
-        elif url_exists(url):  # not check whether it is a git URL
-            return "remote"
-    # case 3 - local path
-    elif is_git_repo(Path(parsed_url.path)):
-        return "local"
-    logger.warning(f"{url} is not a valid URL")
-    return None
 
 
 @cache

--- a/src/lean_dojo/utils.py
+++ b/src/lean_dojo/utils.py
@@ -237,9 +237,13 @@ def read_url(url: str, num_retries: int = 2) -> str:
 
 @cache
 def url_exists(url: str) -> bool:
-    """Return True if the URL ``url`` exists."""
+    """Return True if the URL ``url`` exists, using the GITHUB_ACCESS_TOKEN for authentication if provided."""
     try:
-        with urllib.request.urlopen(url) as _:
+        request = urllib.request.Request(url)
+        gh_token = os.getenv("GITHUB_ACCESS_TOKEN")
+        if gh_token is not None:
+            request.add_header("Authorization", f"token {gh_token}")
+        with urllib.request.urlopen(request) as _:
             return True
     except urllib.error.HTTPError:
         return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,12 +8,18 @@ AESOP_URL = "https://github.com/leanprover-community/aesop"
 MATHLIB4_URL = "https://github.com/leanprover-community/mathlib4"
 LEAN4_EXAMPLE_URL = "https://github.com/yangky11/lean4-example"
 EXAMPLE_COMMIT_HASH = "3f8c5eb303a225cdef609498b8d87262e5ef344b"
+REMOTE_EXAMPLE_URL = "https://gitee.com/rexzong/lean4-example"
 URLS = [
     BATTERIES_URL,
     AESOP_URL,
     MATHLIB4_URL,
     LEAN4_EXAMPLE_URL,
 ]
+
+
+@pytest.fixture(scope="session")
+def remote_example_url():
+    return REMOTE_EXAMPLE_URL
 
 
 @pytest.fixture(scope="session")

--- a/tests/data_extraction/test_cache.py
+++ b/tests/data_extraction/test_cache.py
@@ -1,0 +1,55 @@
+# test for cache manager
+from git import Repo
+from lean_dojo.utils import working_directory
+from pathlib import Path
+from lean_dojo.data_extraction.lean import _format_dirname
+from lean_dojo.data_extraction.cache import cache
+
+
+def test_get_cache(lean4_example_url, remote_example_url, example_commit_hash):
+    # Note: The `git.Repo` requires the local repo to be cloned in a directory
+    # all cached repos are stored in CACHE_DIR/repos
+    prefix = "repos"
+
+    # test local repo cache
+    with working_directory() as tmp_dir:
+        # assume that the local repo placed in `/.../testrepo/lean4-example`
+        repo = Repo.clone_from(lean4_example_url, "testrepo/lean4-example")
+        repo.git.checkout(example_commit_hash)
+        local_dir = tmp_dir / "testrepo/lean4-example"
+        # use local_dir as the key to store the cache
+        rel_cache_dir = (
+            prefix
+            / Path(_format_dirname(str(local_dir), example_commit_hash))
+            / local_dir.name
+        )
+        cache.store(local_dir, rel_cache_dir)
+    # get the cache
+    local_url, local_commit = str(local_dir), example_commit_hash
+    repo_cache = cache.get(local_url, local_commit, prefix)
+    assert (
+        _format_dirname(local_url, local_commit)
+        == f"{local_dir.parent.name}-{local_dir.name}-{local_commit}"
+    )
+    assert repo_cache is not None
+
+    # test remote repo cache
+    with working_directory() as tmp_dir:
+        repo = Repo.clone_from(remote_example_url, "lean4-example")
+        repo.git.checkout(example_commit_hash)
+        tmp_remote_dir = tmp_dir / "lean4-example"
+        # use remote url as the key to store the cache
+        rel_cache_dir = (
+            prefix
+            / Path(_format_dirname(str(remote_example_url), example_commit_hash))
+            / tmp_remote_dir.name
+        )
+        cache.store(tmp_remote_dir, rel_cache_dir)
+    # get the cache
+    remote_url, remote_commit = remote_example_url, example_commit_hash
+    repo_cache = cache.get(remote_url, remote_commit, prefix)
+    assert repo_cache is not None
+    assert (
+        _format_dirname(remote_url, remote_commit)
+        == f"rexzong-lean4-example-{example_commit_hash}"
+    )

--- a/tests/data_extraction/test_lean_repo.py
+++ b/tests/data_extraction/test_lean_repo.py
@@ -3,9 +3,10 @@ from lean_dojo import LeanGitRepo
 from lean_dojo.constants import LEAN4_URL
 from git import Repo
 from github.Repository import Repository
-from lean_dojo.utils import working_directory, repo_type_of_url
+from lean_dojo.utils import working_directory
 from lean_dojo.data_extraction.lean import (
     _to_commit_hash,
+    repo_type_of_url,
     url_to_repo,
     get_latest_commit,
     is_commit_hash,
@@ -24,6 +25,8 @@ def test_url_to_repo(lean4_example_url, remote_example_url):
     ## test url_to_repo & repo_type_of_url
     github_repo = url_to_repo(lean4_example_url)
     assert repo_type_of_url(lean4_example_url) == "github"
+    assert repo_type_of_url("git@github.com:yangky11/lean4-example.git") == "github"
+    assert repo_type_of_url("git@github.com:yangky11/lean4-example") == "github"
     assert isinstance(github_repo, Repository)
     assert github_repo.name == repo_name
 

--- a/tests/data_extraction/test_lean_repo.py
+++ b/tests/data_extraction/test_lean_repo.py
@@ -1,5 +1,7 @@
 # test for the class `LeanGitRepo`
 from lean_dojo import LeanGitRepo
+from lean_dojo.data_extraction.lean import _to_commit_hash
+from lean_dojo.constants import LEAN4_URL
 
 
 def test_lean_git_repo(lean4_example_url, example_commit_hash):
@@ -9,3 +11,19 @@ def test_lean_git_repo(lean4_example_url, example_commit_hash):
     assert repo.exists()
     assert repo.name == "lean4-example"
     assert repo.commit_url == f"{lean4_example_url}/tree/{example_commit_hash}"
+    # test cache directory
+    assert (
+        repo.format_dirname
+        == "yangky11-lean4-example-3f8c5eb303a225cdef609498b8d87262e5ef344b"
+    )
+    # test commit hash
+    ## test commit hash
+    assert _to_commit_hash(repo, example_commit_hash) == example_commit_hash
+    ## test branch, assume the branch is not changed
+    assert _to_commit_hash(repo, "paper") == "8bf74cf67d1acf652a0c74baaa9dc3b9b9e4098c"
+    ## test tag
+    lean4_repo = LeanGitRepo(LEAN4_URL, "master")
+    assert (
+        _to_commit_hash(lean4_repo, "v4.9.1")
+        == "1b78cb4836cf626007bd38872956a6fab8910993"
+    )

--- a/tests/data_extraction/test_lean_repo.py
+++ b/tests/data_extraction/test_lean_repo.py
@@ -1,10 +1,99 @@
 # test for the class `LeanGitRepo`
 from lean_dojo import LeanGitRepo
-from lean_dojo.data_extraction.lean import _to_commit_hash
 from lean_dojo.constants import LEAN4_URL
+from git import Repo
+from github.Repository import Repository
+from lean_dojo.utils import working_directory, repo_type_of_url
+from lean_dojo.data_extraction.lean import (
+    _to_commit_hash,
+    url_to_repo,
+    get_latest_commit,
+    is_commit_hash,
+    GITHUB,
+)
 
 
-def test_lean_git_repo(lean4_example_url, example_commit_hash):
+def test_url_to_repo(lean4_example_url, remote_example_url):
+    repo_name = "lean4-example"
+
+    # 1. github
+    ## test get_latest_commit
+    gh_cm_hash = get_latest_commit(lean4_example_url)
+    assert is_commit_hash(gh_cm_hash)
+
+    ## test url_to_repo & repo_type_of_url
+    github_repo = url_to_repo(lean4_example_url)
+    assert repo_type_of_url(lean4_example_url) == "github"
+    assert isinstance(github_repo, Repository)
+    assert github_repo.name == repo_name
+
+    # 2. local
+    with working_directory() as tmp_dir:
+
+        ## clone from github
+        Repo.clone_from(lean4_example_url, repo_name)
+
+        ## test get_latest_commit
+        local_url = str((tmp_dir / repo_name).absolute())
+        assert get_latest_commit(local_url) == gh_cm_hash
+
+        ## test url_to_repo & repo_type_of_url
+        local_repo = url_to_repo(local_url, repo_type="local")
+        assert repo_type_of_url(local_url) == "local"
+        assert isinstance(local_repo, Repo)
+        assert (
+            local_repo.working_dir != local_url
+        ), "The working directory should not be the same as the original repo"
+
+    # 3. remote
+    with working_directory():
+        remote_repo = url_to_repo(remote_example_url)
+        assert repo_type_of_url(remote_example_url) == "remote"
+        assert isinstance(remote_repo, Repo)
+        re_cm_hash = get_latest_commit(remote_example_url)
+        tmp_repo_path = str(remote_repo.working_dir)
+        assert re_cm_hash == get_latest_commit(tmp_repo_path)
+
+
+def test_to_commit_hash(lean4_example_url, remote_example_url, example_commit_hash):
+    # 1. github
+    repo = GITHUB.get_repo("yangky11/lean4-example")
+    ## commit hash
+    assert _to_commit_hash(repo, example_commit_hash) == example_commit_hash
+    ## branch, assume this branch is not changing
+    assert _to_commit_hash(repo, "paper") == "8bf74cf67d1acf652a0c74baaa9dc3b9b9e4098c"
+    gh_main_hash = _to_commit_hash(repo, "main")
+    ## git tag
+    assert (
+        _to_commit_hash(GITHUB.get_repo("leanprover/lean4"), "v4.9.1")
+        == "1b78cb4836cf626007bd38872956a6fab8910993"
+    )
+    # 2. local
+    with working_directory():
+        repo = Repo.clone_from(lean4_example_url, "lean4-example")
+        repo.git.checkout(example_commit_hash)
+        repo.create_tag("v0.1.0")  # create a tag
+        repo.git.checkout("main")
+        assert _to_commit_hash(repo, example_commit_hash) == example_commit_hash
+        assert _to_commit_hash(repo, "main") == gh_main_hash
+        assert (
+            _to_commit_hash(repo, "origin/paper")
+            == "8bf74cf67d1acf652a0c74baaa9dc3b9b9e4098c"
+        )
+        assert _to_commit_hash(repo, "v0.1.0") == example_commit_hash
+
+    # 3. remote
+    with working_directory():
+        repo = url_to_repo(remote_example_url)
+        assert _to_commit_hash(repo, example_commit_hash) == example_commit_hash
+        assert (
+            _to_commit_hash(repo, "origin/paper")
+            == "8bf74cf67d1acf652a0c74baaa9dc3b9b9e4098c"
+        )
+        # no tags in the remote repo
+
+
+def test_git_lean_repo(lean4_example_url, example_commit_hash):
     repo = LeanGitRepo(lean4_example_url, example_commit_hash)
     assert repo.url == lean4_example_url
     assert repo.commit == example_commit_hash
@@ -12,18 +101,4 @@ def test_lean_git_repo(lean4_example_url, example_commit_hash):
     assert repo.name == "lean4-example"
     assert repo.commit_url == f"{lean4_example_url}/tree/{example_commit_hash}"
     # test cache directory
-    assert (
-        repo.format_dirname
-        == "yangky11-lean4-example-3f8c5eb303a225cdef609498b8d87262e5ef344b"
-    )
-    # test commit hash
-    ## test commit hash
-    assert _to_commit_hash(repo, example_commit_hash) == example_commit_hash
-    ## test branch, assume the branch is not changed
-    assert _to_commit_hash(repo, "paper") == "8bf74cf67d1acf652a0c74baaa9dc3b9b9e4098c"
-    ## test tag
-    lean4_repo = LeanGitRepo(LEAN4_URL, "master")
-    assert (
-        _to_commit_hash(lean4_repo, "v4.9.1")
-        == "1b78cb4836cf626007bd38872956a6fab8910993"
-    )
+    assert repo.format_dirname == f"yangky11-lean4-example-{example_commit_hash}"

--- a/tests/data_extraction/test_trace.py
+++ b/tests/data_extraction/test_trace.py
@@ -1,5 +1,13 @@
 from pathlib import Path
 from lean_dojo import *
+from lean_dojo.data_extraction.cache import cache
+
+
+def test_example_trace(lean4_example_repo):
+    trace_repo = trace(lean4_example_repo)
+    repo = trace_repo.repo
+    path = cache.get(repo.url, repo.commit)
+    assert path is not None
 
 
 def test_trace(traced_repo):


### PR DESCRIPTION
### Main Changes

1. **Lean Version**: Use **string** for `lean_version` instead of a **commit hash**. Postpone the initialization of the Lean4 repository.
2. **Cache**: Update `cache.get` and `cache.store` for increased flexibility.
3. **Repository Type**: Extend function capabilities to support new repository types, such as `_to_commit_hash`, `normalize_url`, `get_latest_commit`, and `url_to_repo`, each with tests to ensure reliability.

### Progress

Implementation plan for the new feature:
- [x] Integrate `gitpython` into the project (#188).
- [ ] Enhance function capabilities to support new repo types (current PR).
- [ ] Add two new repository types for tracing and interaction  (#179).