### PR TITLE
(minor edit) Specifying get_premise_definitions premise locations

### DIFF
--- a/src/lean_dojo/data_extraction/traced_data.py
+++ b/src/lean_dojo/data_extraction/traced_data.py
@@ -838,7 +838,8 @@ class TracedFile:
 
     def get_premise_definitions(self) -> List[Dict[str, Any]]:
         """Return all theorems and definitions defined in the current file that
-        can be potentially used as premises.
+        can be potentially used as premises, including the premises in the theorem
+        statement and premises in the tactics used to prove the theorem. 
 
         Returns:
             List[Dict[str, Any]]: _description_


### PR DESCRIPTION
I assumed get_premise_definitions only took premises from the tactics of the theorem, and it took a reasonably long time to find that it didn't only do that.

(To just take tactics, loop over all tactics in a theorem, then use the [get_annotated_tactic()](https://leandojo.readthedocs.io/en/latest/traced_data.html#lean_dojo.data_extraction.traced_data.TracedTactic.get_annotated_tactic) property of a tactic; the first index of `tactic.get_annotated_tactic` will contain a dict of which one key to value pair is `full_name` to the desired premise.)