### PR TITLE
allow submodule for local type

### DIFF
--- a/src/lean_dojo/data_extraction/lean.py
+++ b/src/lean_dojo/data_extraction/lean.py
@@ -8,7 +8,6 @@ import json
 import toml
 import time
 import urllib
-import shutil
 import tempfile
 import webbrowser
 from enum import Enum
@@ -155,10 +154,8 @@ def url_to_repo(
                 repo_name = os.path.basename(url)
                 if repo_type == RepoType.LOCAL:
                     assert is_git_repo(url), f"Local path {url} is not a git repo"
-                    shutil.copytree(url, repo_name)
-                    return Repo(repo_name)
-                else:
-                    return Repo.clone_from(url, repo_name)
+                # clone from local path or remote url
+                return Repo.clone_from(url, repo_name)
         except Exception as ex:
             if num_retries <= 0:
                 raise ex


### PR DESCRIPTION

Replace `shutil.copytree(local_path, repo_name)` with `Repo.clone_from(local_path, repo_name)` for `Local` type in `url_to_repo`.

This change ensures the cached repo is clean and fixes bugs when dealing with submodule repositories.

To reproduce the issue:

```python
# git clone https://github.com/Lean-zh/IMO_Resource.git && cd IMO_Resource
# git submodule update --init --recursive
# cd IMO_Resource
from lean_dojo import LeanGitRepo
LeanGitRepo.from_path('IMO_2024')
# ValueError: Error converting ref to commit hash: SHA is empty, possible dubious ownership in the repository at /tmp/tmp4n56k8qf/IMO_2024.
```

The submodule is in fact not a complete Git repo, which leads to errors:
```bash
❯ cat IMO_2024/.git
gitdir: ../.git/modules/IMO_2024
```
