### PR TITLE
Allow arbitrary python 3.12 versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ description = "LeanDojo: Machine Learning for Theorem Proving in Lean"
 keywords = ["theorem proving", "machine learning", "Lean"]
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.9,<=3.12"  # https://docs.ray.io/en/latest/ray-overview/installation.html#daily-releases-nightlies
+requires-python = ">=3.9,<3.13"  # https://docs.ray.io/en/latest/ray-overview/installation.html#daily-releases-nightlies
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
The current one disallows any python version `> 3.12.0`, including for example `3.12.1`.